### PR TITLE
Add use statment for Element

### DIFF
--- a/preprocess/paragraph.preprocess.php
+++ b/preprocess/paragraph.preprocess.php
@@ -22,6 +22,7 @@
 
 use Drupal\Component\Utility\Html;
 use Drupal\Core\Url;
+use Drupal\Core\Render\Element;
 
 /**
  * Implements hook_preprocess_paragraph().


### PR DESCRIPTION
`Element::children(` is used in a couple of preprocess hooks, was missing the use statement.